### PR TITLE
placeholder для кнопки DatePickerRange вместо периода

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "modul-components",
-  "version": "0.0.51",
+  "version": "0.0.52",
   "description": "",
   "main": "./lib",
   "module": "./src/components",

--- a/src/components/DatePickerRange.js
+++ b/src/components/DatePickerRange.js
@@ -100,15 +100,15 @@ class DatePickerRange extends React.Component {
     }
 
     render() {
-        const {ignoreDropCloseAttr, dateFrom, dateTo, className, periods, position = "bottom left"}=this.props;
+        const {ignoreDropCloseAttr, dateFrom, dateTo, className, periods, position = "bottom left", placeholder}=this.props;
 
         const dateFromStr = dateFrom ? dateHelper.dateFormat(dateFrom, 'd mmmm:R') : '';
         const dateToStr = dateTo ? dateHelper.dateFormat(dateTo, 'd mmmm:R') : '';
 
         const list = periods || Object.keys(PERIOD);
 
-        let title = 'Выберите период';
-        if (dateFrom || dateTo) {
+        let title = placeholder || 'Выберите период';
+        if (!placeholder && (dateFrom || dateTo)) {
             title = '';
             if (dateFrom)
                 title = `с ${dateFromStr} `;
@@ -156,6 +156,7 @@ DatePickerRange.propTypes = {
     dateTo: PropTypes.any,
     position: PropTypes.string,
     periods: PropTypes.array,
+    placeholder: PropTypes.string
 };
 
 export default DatePickerRange;


### PR DESCRIPTION
Если указать в `props` аттрибут `placeholder={string}` то текст на кнопке, открывающей выпадающий список с выбором периода дат не будет меняться и будет всегда иметь значение из атрибута `placeholder`

пример
```jsx
<DatePickerRange {...dateRange}
  placeholder={"скачать отчет о продажах"}
  onChange={selectDateRange}
  periods={allowPeriods}
  className={'grey small'}
/>
```