### PR TITLE
Поддержка события итогового выбора временного отрезка со скрытием дропа

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "modul-components",
-  "version": "0.0.52",
+  "version": "0.0.53",
   "description": "",
   "main": "./lib",
   "module": "./src/components",

--- a/src/components/DatePickerRange.js
+++ b/src/components/DatePickerRange.js
@@ -153,6 +153,7 @@ class DatePickerRange extends React.Component {
 DatePickerRange.propTypes = {
     setDropInstance: PropTypes.func,
     onChange: PropTypes.func,
+    onBlur: PropTypes.func,
     ignoreDropCloseAttr: PropTypes.string,
     dateFrom: PropTypes.any,
     dateTo: PropTypes.any,

--- a/src/components/DatePickerRange.js
+++ b/src/components/DatePickerRange.js
@@ -60,8 +60,8 @@ function getDateRangeByPeriod(period) {
 
 class DatePickerRange extends React.Component {
     static defaultProps = {
-        onChange: () => {
-        },
+        onChange: () => {},
+        onBlur: () => {},
         ignoreDropCloseAttr: '',
         className: 'light small',
         periods: null
@@ -76,6 +76,7 @@ class DatePickerRange extends React.Component {
     handleSelectPeriod(period) {
         const dateRange = getDateRangeByPeriod(period);
         this.props.onChange(dateRange);
+        this.props.onBlur(dateRange);
     }
 
     handleChangeDateFrom(date) {
@@ -93,10 +94,11 @@ class DatePickerRange extends React.Component {
     }
 
     handleSelectDateRange() {
-        this.props.onChange({
-            dateFrom: this.dropFrom.getValue(),
-            dateTo: this.dropTo.getValue()
-        });
+        const dateFrom = this.dropFrom.getValue();
+        const dateTo   = this.dropTo.getValue();
+        const period   = {dateFrom, dateTo};
+        this.props.onChange(period);
+        this.props.onBlur(period);
     }
 
     render() {


### PR DESCRIPTION
событие `onChange` вызывается постоянно, а иногда надо чтобы событие изменения периода вызывалось только с закрытием выпадушки (в связи с выбором значения - клик по периоду либо по кнопке "ок") - такое событие теперь можно создать, атрибут `onBlur` в `props`

пример
```jsx
<DatePickerRange
  onBlur={({dateFrom, dateTo}) => onSelectPeriodHandler({dateFrom, dateTo})}
/>
```